### PR TITLE
Added viper config for servers, auth user and pwd

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -8,6 +8,12 @@
   version = "v1.1.0"
 
 [[projects]]
+  name = "github.com/fsnotify/fsnotify"
+  packages = ["."]
+  revision = "c2828203cd70a50dcccfb2761f8b1f8ceef9a8e9"
+  version = "v1.4.7"
+
+[[projects]]
   name = "github.com/go-errors/errors"
   packages = ["."]
   revision = "a6af135bd4e28680facf08a3d206b454abc877a4"
@@ -18,6 +24,23 @@
   packages = ["."]
   revision = "d523deb1b23d913de5bdada721a6071e71283618"
   version = "v1.4.0"
+
+[[projects]]
+  branch = "master"
+  name = "github.com/hashicorp/hcl"
+  packages = [
+    ".",
+    "hcl/ast",
+    "hcl/parser",
+    "hcl/printer",
+    "hcl/scanner",
+    "hcl/strconv",
+    "hcl/token",
+    "json/parser",
+    "json/scanner",
+    "json/token"
+  ]
+  revision = "ef8a98b0bbce4a65b5aa4c368430a80ddc533168"
 
 [[projects]]
   name = "github.com/inconshreveable/mousetrap"
@@ -33,6 +56,18 @@
     "oid"
   ]
   revision = "90697d60dd844d5ef6ff15135d0203f65d2f53b8"
+
+[[projects]]
+  name = "github.com/magiconair/properties"
+  packages = ["."]
+  revision = "c2353362d570a7bfa228149c62842019201cfb71"
+  version = "v1.8.0"
+
+[[projects]]
+  branch = "master"
+  name = "github.com/mitchellh/mapstructure"
+  packages = ["."]
+  revision = "bb74f1db0675b241733089d5a1faa5dd8b0ef57b"
 
 [[projects]]
   name = "github.com/ory-am/common"
@@ -51,6 +86,12 @@
   packages = ["."]
   revision = "e790cca94e6cc75c7064b1332e63811d4aae1a53"
   version = "v1.1"
+
+[[projects]]
+  name = "github.com/pelletier/go-toml"
+  packages = ["."]
+  revision = "c01d1270ff3e442a8a57cddc1c92dc1138598194"
+  version = "v1.2.0"
 
 [[projects]]
   name = "github.com/pkg/errors"
@@ -77,16 +118,43 @@
   version = "v1.0.5"
 
 [[projects]]
+  name = "github.com/spf13/afero"
+  packages = [
+    ".",
+    "mem"
+  ]
+  revision = "787d034dfe70e44075ccc060d346146ef53270ad"
+  version = "v1.1.1"
+
+[[projects]]
+  name = "github.com/spf13/cast"
+  packages = ["."]
+  revision = "8965335b8c7107321228e3e3702cab9832751bac"
+  version = "v1.2.0"
+
+[[projects]]
   name = "github.com/spf13/cobra"
   packages = ["."]
   revision = "ef82de70bb3f60c65fb8eebacbb2d122ef517385"
   version = "v0.0.3"
 
 [[projects]]
+  branch = "master"
+  name = "github.com/spf13/jwalterweatherman"
+  packages = ["."]
+  revision = "7c0cea34c8ece3fbeb2b27ab9b59511d360fb394"
+
+[[projects]]
   name = "github.com/spf13/pflag"
   packages = ["."]
   revision = "583c0c0531f06d5278b7d917446061adc344b5cd"
   version = "v1.0.1"
+
+[[projects]]
+  name = "github.com/spf13/viper"
+  packages = ["."]
+  revision = "b5e8006cbee93ec955a89ab31e0e3ce3204f3736"
+  version = "v1.0.2"
 
 [[projects]]
   name = "github.com/stretchr/testify"
@@ -113,14 +181,33 @@
   revision = "ce36f3865eeb42541ce3f87f32f8462c5687befa"
 
 [[projects]]
+  name = "golang.org/x/text"
+  packages = [
+    "internal/gen",
+    "internal/triegen",
+    "internal/ucd",
+    "transform",
+    "unicode/cldr",
+    "unicode/norm"
+  ]
+  revision = "f21a4dfb5e38f5895301dc265a8def02365cc3d0"
+  version = "v0.3.0"
+
+[[projects]]
   name = "google.golang.org/appengine"
   packages = ["cloudsql"]
   revision = "b1f26356af11148e710935ed1ac8a7f5702c7612"
   version = "v1.1.0"
 
+[[projects]]
+  name = "gopkg.in/yaml.v2"
+  packages = ["."]
+  revision = "5420a8b6744d3b0345ab293f6fcba19c978f1183"
+  version = "v2.2.1"
+
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "7ff64b5e317b5e187b4f5da4813d08e1190ded6f718fba2a10bd2dd81e1fb5b0"
+  inputs-digest = "d345299923fc3c8e76dbf8dcf9010fd858f379e97e3a6bf7eb0057c65abbc5ac"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/README.md
+++ b/README.md
@@ -25,32 +25,42 @@ Usage:
   zkcli [command]
 
 Available Commands:
-  create      
-  creater     
-  delete      
-  deleter     
-  exists      
-  get         
-  getacl      
+  create      Create the specified znode
+  creater     Create the specified znode, as well as any required parents
+  delete      Delete the specified znode
+  deleter     Delete the specified znode, as well as any children
+  exists      Check if the specified znode exists
+  get         Get the value of the specified znode
+  getacl      Get the ACL associated with a znode
   help        Help about any command
-  ls          
-  lsr         
-  rm          
-  rmr         
-  set         
-  setacl      
+  ls          Get the children of the specified znode
+  lsr         Print the children of the current znode recursively
+  set         Set the value of the specified znode
+  setacl      Set the ACL of the specified znode
 
 Flags:
-      --auth_pwd string   optional, digest scheme, pwd
-      --auth_usr string   optional, digest scheme, user
+      --auth_pwd string   optional, digest scheme, pwd (Can be configured with the environment variable ZKCLI_AUTH_PWD)
+      --auth_usr string   optional, digest scheme, user (Can be configured with the environment variable ZKCLI_AUTH_USER)
       --debug             debug mode (very verbose)
       --force             force operation
       --format string     output format (txt|json) (default "txt")
   -h, --help              help for zkcli
       --n                 omit trailing newline
-      --servers string    srv1[:port1][,srv2[:port2]...]
+      --servers string    srv1[:port1][,srv2[:port2]...] (Can be configured with the environment variable ZKCLI_SERVERS)
       --verbose           verbose
+
+Use "zkcli [command] --help" for more information about a command.
 ```
+
+#### Configuration
+
+There are environment variables that can be used instead of command line flags, to reduce the amount that has to be entered
+
+| Flag        | Environment Variable |
+|-------------|----------------------|
+| `--servers`   | `ZKCLI_SERVERS`        |
+| `--auth_user` | `ZKCLI_AUTH_USER`      |
+| `--auth_pwd`  | `ZKCLI_AUTH_PWD`       |
 
 ### Examples:
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -81,14 +81,14 @@ func init() {
 	stdin = os.Stdin
 	osExit = os.Exit
 
-	rootCmd.PersistentFlags().StringVar(&servers, serverFlag, defaultServer, "srv1[:port1][,srv2[:port2]...]")
+	rootCmd.PersistentFlags().StringVar(&servers, serverFlag, defaultServer, "srv1[:port1][,srv2[:port2]...] (Can be configured with the environment variable " + serverEnv + ")")
 	rootCmd.PersistentFlags().BoolVar(&force, forceFlag, defaultForce, "force operation")
 	rootCmd.PersistentFlags().StringVar(&format, formatFlag, defaultFormat, "output format ("+txtFormat+"|"+jsonFormat+")")
 	rootCmd.PersistentFlags().BoolVar(&omitNewline, omitNewlineFlag, defaultOmitnewline, "omit trailing newline")
 	rootCmd.PersistentFlags().BoolVar(&verbose, verboseFlag, defaultVerbose, "verbose")
 	rootCmd.PersistentFlags().BoolVar(&debug, debugFlag, defaultDebug, "debug mode (very verbose)")
-	rootCmd.PersistentFlags().StringVar(&authUser, authUserFlag, defaultAuthUser, "optional, digest scheme, user")
-	rootCmd.PersistentFlags().StringVar(&authPwd, authPwdFlag, defaultAuthPwd, "optional, digest scheme, pwd")
+	rootCmd.PersistentFlags().StringVar(&authUser, authUserFlag, defaultAuthUser, "optional, digest scheme, user (Can be configured with the environment variable " + authUserEnv + ")")
+	rootCmd.PersistentFlags().StringVar(&authPwd, authPwdFlag, defaultAuthPwd, "optional, digest scheme, pwd (Can be configured with the environment variable " + authPwdEnv + ")")
 
 	viper.BindEnv(serverFlag, serverEnv)
 	viper.BindEnv(authUserFlag, authUserEnv)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -11,6 +11,7 @@ import (
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 
 	"github.com/fJancsoSzabo/zkcli/output"
 	"github.com/fJancsoSzabo/zkcli/zk"
@@ -76,15 +77,24 @@ func init() {
 	stdin = os.Stdin
 	osExit = os.Exit
 
-	rootCmd.PersistentFlags().StringVar(&servers, serverFlag, defaultServer, "srv1[:port1][,srv2[:port2]...]")
+	rootCmd.PersistentFlags().String(serverFlag, defaultServer, "srv1[:port1][,srv2[:port2]...]")
 	rootCmd.PersistentFlags().BoolVar(&force, forceFlag, defaultForce, "force operation")
 	rootCmd.PersistentFlags().StringVar(&format, formatFlag, defaultFormat, "output format ("+txtFormat+"|"+jsonFormat+")")
 	rootCmd.PersistentFlags().BoolVar(&omitNewline, omitNewlineFlag, defaultOmitnewline, "omit trailing newline")
 	rootCmd.PersistentFlags().BoolVar(&verbose, verboseFlag, defaultVerbose, "verbose")
 	rootCmd.PersistentFlags().BoolVar(&debug, debugFlag, defaultDebug, "debug mode (very verbose)")
-	rootCmd.PersistentFlags().StringVar(&authUser, authUserFlag, defaultAuthUser, "optional, digest scheme, user")
-	rootCmd.PersistentFlags().StringVar(&authPwd, authPwdFlag, defaultAuthPwd, "optional, digest scheme, pwd")
+	rootCmd.PersistentFlags().String(authUserFlag, defaultAuthUser, "optional, digest scheme, user")
+	rootCmd.PersistentFlags().String(authPwdFlag, defaultAuthPwd, "optional, digest scheme, pwd")
 
+	viper.BindPFlag(serverFlag, rootCmd.PersistentFlags().Lookup(serverFlag))
+	viper.BindPFlag(authUserFlag, rootCmd.PersistentFlags().Lookup(authUserFlag))
+	viper.BindPFlag(authPwdFlag, rootCmd.PersistentFlags().Lookup(authPwdFlag))
+	viper.BindEnv(serverFlag, "ZKCLI_SERVERS")
+	viper.BindEnv(authUserFlag, "ZKCLI_AUTH_USER")
+	viper.BindEnv(authPwdFlag, "ZKCLI_AUTH_PWD")
+	servers = viper.Get(serverFlag).(string)
+	authUser = viper.Get(authUserFlag).(string)
+	authPwd = viper.Get(authPwdFlag).(string)
 }
 
 var rootCmd = &cobra.Command{


### PR DESCRIPTION
Resolves outbrain/zookeepercli#27.

Add viper configs for `--servers`, `--auth_user` and `--auth_pwd` flags.